### PR TITLE
Use relative paths for service worker caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -2,10 +2,10 @@ self.addEventListener('install', event => {
   event.waitUntil(
     caches.open('warewash-v1').then(cache => {
       return cache.addAll([
-        '/',
-        '/index.html',
-        '/ContentsEditor.html',
-        '/dist/output.css'
+        './',
+        './index.html',
+        './ContentsEditor.html',
+        './output.css'
       ]);
     })
   );


### PR DESCRIPTION
## Summary
- use relative URLs in service worker cache list so it works when deployed in a subdirectory

## Testing
- `npm run build`
- `node sw-test.js` (service worker mock: root/index/editor 200)


------
https://chatgpt.com/codex/tasks/task_e_689111b8cb488321b6adae7555d14528